### PR TITLE
Work-around markdownlinter false positives

### DIFF
--- a/script/test-markdown.sh
+++ b/script/test-markdown.sh
@@ -17,5 +17,7 @@
 # MD026 Trailing punctuation in header
 # MD032 Lists should be surrounded by blank lines
 # MD034 Bare URL used
-#
-bundle exec mdl -r ~MD007,~MD013,~MD029,~MD024,~MD026,~MD032,~MD034 -i -g '.'
+# MD055 Table row doesn't begin/end with pipes
+# MD057 Table has missing or invalid header separation
+
+bundle exec mdl -r ~MD007,~MD013,~MD029,~MD024,~MD026,~MD032,~MD034,~MD055,~MD057 -i -g '.'


### PR DESCRIPTION
The markdown linter does not recognise the liquid code sections, it sees the pipe ("|") and mis-identifies it as a broken table

We tied various ways to exclude the sections but
we have not found a way which works

For now, we ignore those rules