### PR TITLE
Add section for assessment links

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,3 +17,17 @@ Advice specific to each requirement goes below the requirement heading.
 
 * [Criteria](criteria/){% assign sorted = site.pages| sort:"order" %}{% for page in sorted %}{% if page.dir == "/criteria/" %}{% if page.name != "index.md" %}{% if page.title %}
   * [{{page.title}}](.{{page.url}}){% endif%}{% endif%}{% endif%}{% endfor %}
+
+## Public assessments
+
+Below is a list of codebases that have made a Standard for Public Code assessment.
+They can serve as an inspiration if you want to see how others are meeting the requirements of the standard.
+
+| Codebase Repository | Assessment link | Version |
+|---|---|---|
+| [Standard for Public Code](https://github.com/standard-for-public-code/standard-for-public-code) | [Link](https://www.standardforpubliccode.org/docs/standard-for-public-code.html) | 0.8.1 |
+| [Governance Game](https://github.com/governance-game/governance-game) | [Link](https://github.com/governance-game/governance-game/blob/develop/standard-for-public-code-assessment.html) | 0.7.0 |
+| [Govdirectory](https://github.com/govdirectory/website) | [Link](https://www.govdirectory.org/standard-for-public-code/) | 0.8.0 |
+
+If you want the assessment of a codebase you maintain or contribute to to be added to this list, we invite you to [make a pull request](https://github.com/standard-for-public-code/community-implementation-guide-standard/compare).
+Out of courtesy, we ask you to only add links to assessments where you have the consent of that codebase's community.


### PR DESCRIPTION
Fixes #117

Starting by adding three codebases I know are okay with being linked.