### PR TITLE
Add links to list of users of the Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If the proposal is specific to a requirement, then the example should be place u
 If the proposal is spanning several requirements of a criterion, it should be placed in the criterion above the requirements.
 If the proposal spans multiple criteria it should be above the list of criteria.
 
-For inspiration of existing solutions that may not have been added here yet, check the assessments of [users of the Standard for Public Code](https://github.com/standard-for-public-code#whos-using-the-standard-for-public-code).
+For further real world examples of Standard for Public Code implementation, check out [existing users' assessments against the Standard](https://github.com/standard-for-public-code#whos-using-the-standard-for-public-code).
 
 ### Review of a contributions
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ If the proposal is specific to a requirement, then the example should be place u
 If the proposal is spanning several requirements of a criterion, it should be placed in the criterion above the requirements.
 If the proposal spans multiple criteria it should be above the list of criteria.
 
+For inspiration of existing solutions that may not have been added here yet, check the assessments of [users of the Standard for Public Code](https://github.com/standard-for-public-code#whos-using-the-standard-for-public-code).
+
 ### Review of a contributions
 
 Before we merge a pull request of a new or updated proposal, it needs to be reviewed.

--- a/index.md
+++ b/index.md
@@ -7,6 +7,8 @@ The things that are added should almost be considered to be "pre-approved", mean
 
 We should keep in mind "there's more than one way to do it": where it makes sense, provide multiple options, especially linking to examples.
 
+For inspiration of existing solutions that may not have been added here yet, check the assessments of [users of the Standard for Public Code](https://github.com/standard-for-public-code#whos-using-the-standard-for-public-code).
+
 The guide could also invite for conversation about solutions in specific cases.
 
 It may have some general advice inspired by the sections "How to test", "What you need to do" and "Further reading" sessions.

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ The things that are added should almost be considered to be "pre-approved", mean
 
 We should keep in mind "there's more than one way to do it": where it makes sense, provide multiple options, especially linking to examples.
 
-For inspiration of existing solutions that may not have been added here yet, check the assessments of [users of the Standard for Public Code](https://github.com/standard-for-public-code#whos-using-the-standard-for-public-code).
+For further inspiration, check out [existing users' assessments against the Standard for Public Code](https://github.com/standard-for-public-code#whos-using-the-standard-for-public-code).
 
 The guide could also invite for conversation about solutions in specific cases.
 


### PR DESCRIPTION
Added both in README and index as it may also inspire contributions to this guide.

Part of the fix for https://github.com/standard-for-public-code/standard-for-public-code/discussions/1152