### PR TITLE
Update links to Dutch local and national software catalogs

### DIFF
--- a/criteria/make-the-codebase-findable.md
+++ b/criteria/make-the-codebase-findable.md
@@ -34,7 +34,8 @@ Catalogs to consider:
 * [Katalog över öppen programvara inom offentlig sektor](https://offentligkod.se/), only for codebases used by Swedish public organizations
 * [Developers Italia Software](https://developers.italia.it/it/software.html), Italian but accepts others
 * [CodeGouv](https://code.gouv.fr/), French
-* [Developer Overheid repositories](https://developer.overheid.nl/repositorys), Dutch
+* [Common Ground component catalog](https://commonground.opencatalogi.nl/components), Dutch
+* [Developer Overheid OSS-register](https://oss.developer.overheid.nl/), Dutch
 * [Open CoDE](https://gitlab.opencode.de/explore), German
 
 ### The codebase SHOULD have a website which describes the problem the codebase solves using the preferred jargon of different potential users of the codebase (including technologists, policy experts and managers).

--- a/criteria/make-the-codebase-findable.md
+++ b/criteria/make-the-codebase-findable.md
@@ -35,7 +35,6 @@ Catalogs to consider:
 * [Developers Italia Software](https://developers.italia.it/it/software.html), Italian but accepts others
 * [CodeGouv](https://code.gouv.fr/), French
 * [Developer Overheid repositories](https://developer.overheid.nl/repositorys), Dutch
-* [Common Ground software products](https://componentencatalogus.commonground.nl/producten), Dutch
 * [Open CoDE](https://gitlab.opencode.de/explore), German
 
 ### The codebase SHOULD have a website which describes the problem the codebase solves using the preferred jargon of different potential users of the codebase (including technologists, policy experts and managers).


### PR DESCRIPTION
Dead URL. A quick search doesn't turn up a correct, functional URL (either for the a product by this name or a plausible successor product).