### PR TITLE
GitHub community health files

### DIFF
--- a/criteria/document-codebase-objectives.md
+++ b/criteria/document-codebase-objectives.md
@@ -25,6 +25,10 @@ Be on the lookout for people, organizations and initiatives with similar objecti
 
 ### Codebase documentation SHOULD clearly describe the connections between policy objectives and codebase objectives.
 
+#### Resources
+
+* [Instructions for adding a README file on GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes). This is linked as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+
 #### Examples
 
 ### Documenting the objectives of the codebase for the general public is OPTIONAL.

--- a/criteria/document-the-code.md
+++ b/criteria/document-the-code.md
@@ -20,6 +20,7 @@ redirect_from:
 ### Resources
 
 * [How to write a README](https://github.com/Amsterdam/amsterdam.github.io/blob/master/guides/write-a-readme.md), guide from the municipality of Amsterdam.
+* [Instructions for adding a README file on GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes). This is linked as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
 
 ## Requirements
 

--- a/criteria/maintain-version-control.md
+++ b/criteria/maintain-version-control.md
@@ -40,6 +40,9 @@ Git is great.
 
 ### Contribution guidelines SHOULD require contributors to group relevant changes in commits.
 
+* [Instructions for adding a CONTRIBUTING file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors), linked in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+
+
 ### Maintainers SHOULD mark released versions of the codebase, for example using revision tags or textual labels.
 
 #### Examples

--- a/criteria/maintain-version-control.md
+++ b/criteria/maintain-version-control.md
@@ -42,7 +42,6 @@ Git is great.
 
 * [Instructions for adding a CONTRIBUTING file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors), linked in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
 
-
 ### Maintainers SHOULD mark released versions of the codebase, for example using revision tags or textual labels.
 
 #### Examples

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -85,5 +85,3 @@ Preferably, anyone should be able to join these and start discussing without req
 #### Examples
 
 ### The documentation MUST include instructions for how to report potentially security sensitive issues.
-
-

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -17,13 +17,6 @@ order: 5
 * (add a good gitlab example)
 * [Tasks in Phabricator](https://phabricator.wikimedia.org/maniphest/)
 
-### The codebase MUST include instructions for how to privately report security issues for responsible disclosure.
-
-#### Examples
-
-* [OpenZaak SECURITY](https://github.com/open-zaak/open-zaak/blob/main/SECURITY.rst)
-* [Verdaccio SECURITY](https://github.com/verdaccio/verdaccio/blob/master/SECURITY.md)
-
 ### The documentation MUST link to both the public issue tracker and submitted codebase changes, for example in a README file.
 
 In many platforms, like GitHub, GitLab, Gitea etc. these links are automatically provided in the interface. If you don't use the features of the platform, for example if you have a separate issue tracker, then you must provide these links.
@@ -74,13 +67,19 @@ Preferably, anyone should be able to join these and start discussing without req
 * [CivicTech Sweden (matrix)](https://app.element.io/#/room/#civictechse:matrix.org)
 * [Publiccode.yml forum (GitHub discussions)](https://github.com/publiccodeyml/publiccode.yml/discussions)
 
-### There MUST be a way to report security issues for responsible disclosure over a closed channel.
+### The codebase MUST include instructions for how to privately report security issues for responsible disclosure.
 
-#### Examples
+#### Resources
 
-### The documentation MUST include instructions for how to report potentially security sensitive issues.
+* [Instructions for adding a SECURITY file on GitHub](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/add-security-policy). This is includes a minimal template and can be used to set up a 'report a vulnerability' button. It's also linked as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
 
 #### Examples
 
 * [OpenZaak SECURITY](https://github.com/open-zaak/open-zaak/blob/main/SECURITY.rst)
 * [Verdaccio SECURITY](https://github.com/verdaccio/verdaccio/blob/master/SECURITY.md)
+
+#### Examples
+
+### The documentation MUST include instructions for how to report potentially security sensitive issues.
+
+

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -21,6 +21,10 @@ order: 5
 
 In many platforms, like GitHub, GitLab, Gitea etc. these links are automatically provided in the interface. If you don't use the features of the platform, for example if you have a separate issue tracker, then you must provide these links.
 
+#### Resources
+
+* [Instructions for adding a README file on GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes). This is linked as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+
 #### Further reading
 
 * [18Fs Open Source Guide on `README`s](https://github.com/18F/open-source-guide/blob/18f-pages/pages/making-readmes-readable.md)

--- a/criteria/make-contributing-easy.md
+++ b/criteria/make-contributing-easy.md
@@ -71,7 +71,7 @@ Preferably, anyone should be able to join these and start discussing without req
 * [CivicTech Sweden (matrix)](https://app.element.io/#/room/#civictechse:matrix.org)
 * [Publiccode.yml forum (GitHub discussions)](https://github.com/publiccodeyml/publiccode.yml/discussions)
 
-### The codebase MUST include instructions for how to privately report security issues for responsible disclosure.
+### There MUST be a way to report security issues for responsible disclosure over a closed channel.
 
 #### Resources
 
@@ -82,6 +82,6 @@ Preferably, anyone should be able to join these and start discussing without req
 * [OpenZaak SECURITY](https://github.com/open-zaak/open-zaak/blob/main/SECURITY.rst)
 * [Verdaccio SECURITY](https://github.com/verdaccio/verdaccio/blob/master/SECURITY.md)
 
-#### Examples
-
 ### The documentation MUST include instructions for how to report potentially security sensitive issues.
+
+#### Examples

--- a/criteria/publish-with-an-open-license.md
+++ b/criteria/publish-with-an-open-license.md
@@ -30,7 +30,6 @@ redirect_from:
 
 * [Instructions for adding a LICENSE file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository). This includes templates for common open source licenses, and is linked as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
 
-
 ### Contributors MUST NOT be required to transfer copyright of their contributions to the codebase.
 
 This may be impossible for civil servants in some jurisdictions so if that is a requirement they are effectively prohibited from contributing.

--- a/criteria/publish-with-an-open-license.md
+++ b/criteria/publish-with-an-open-license.md
@@ -28,6 +28,9 @@ redirect_from:
 
 ### All source code MUST be published with a license file.
 
+* [Instructions for adding a LICENSE file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-license-to-a-repository). This includes templates for common open source licenses, and is linked as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+
+
 ### Contributors MUST NOT be required to transfer copyright of their contributions to the codebase.
 
 This may be impossible for civil servants in some jurisdictions so if that is a requirement they are effectively prohibited from contributing.

--- a/criteria/use-a-coherent-style.md
+++ b/criteria/use-a-coherent-style.md
@@ -10,6 +10,10 @@ edirect_from:
 
 ## Requirements
 
+* [Instructions for adding a CONTRIBUTING file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors). GitHub links CONTRIBUTING in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+
+
+
 ## Use a coherent style
 
 ### The codebase MUST use a coding or writing style guide, either the codebase community's own or an existing one referred to in the codebase.

--- a/criteria/use-a-coherent-style.md
+++ b/criteria/use-a-coherent-style.md
@@ -12,8 +12,6 @@ edirect_from:
 
 * [Instructions for adding a CONTRIBUTING file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors). GitHub links CONTRIBUTING in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
 
-
-
 ## Use a coherent style
 
 ### The codebase MUST use a coding or writing style guide, either the codebase community's own or an existing one referred to in the codebase.

--- a/criteria/welcome-contributors.md
+++ b/criteria/welcome-contributors.md
@@ -24,7 +24,6 @@ redirect_from:
 
 * [Instructions for adding a CONTRIBUTING file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors), linked in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
 
-
 #### Examples
 
 * [OpenZaak CONTRIBUTING](https://github.com/open-zaak/open-zaak/blob/main/CONTRIBUTING.md)
@@ -84,7 +83,6 @@ This could also be solved by having public task boards/kanban boards with suitab
 #### Resources
 
 * [Instructions for adding a CODE_OF_CONDUCT file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project). This includes templates for common Codes of Conduct (like the Contributor Covenant), and is linked in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
-
 
 #### Examples
 

--- a/criteria/welcome-contributors.md
+++ b/criteria/welcome-contributors.md
@@ -81,6 +81,11 @@ This could also be solved by having public task boards/kanban boards with suitab
 
 ### Including a code of conduct for contributors in the codebase is OPTIONAL.
 
+#### Resources
+
+* [Instructions for adding a CODE_OF_CONDUCT file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project). This includes templates for common Codes of Conduct (including the Contributor Covenant), and links in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+
+
 #### Examples
 
 * [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/) is a code of conduct with a set of core values and norms that are essential in a just and equitable software commons. It can be adapted to include the special shared values and norms particular to your own community and its members.

--- a/criteria/welcome-contributors.md
+++ b/criteria/welcome-contributors.md
@@ -83,7 +83,7 @@ This could also be solved by having public task boards/kanban boards with suitab
 
 #### Resources
 
-* [Instructions for adding a CODE_OF_CONDUCT file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project). This includes templates for common Codes of Conduct (including the Contributor Covenant), and links in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+* [Instructions for adding a CODE_OF_CONDUCT file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-a-code-of-conduct-to-your-project). This includes templates for common Codes of Conduct (like the Contributor Covenant), and is linked in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
 
 
 #### Examples

--- a/criteria/welcome-contributors.md
+++ b/criteria/welcome-contributors.md
@@ -22,7 +22,8 @@ redirect_from:
 
 #### Resources
 
-* [Instructions for adding a CONTRIBUTING file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)
+* [Instructions for adding a CONTRIBUTING file on GitHub](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors), linked in multiple places as part of a [repo's community profile](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories).
+
 
 #### Examples
 


### PR DESCRIPTION
This implements #123. 

I'd like feedback on my approach. I've gone for completeness and added the Github instructions for adding a community health file to every criterion where the content fulfilling that criterion lives naturally in that file (example: a CONTRIBUTING could contain content on both coding style and how to group changes in commits).

But it results in potentially reduced readability, since the same or similar content is reproduced in multiple places. A different approach would be to link once to the file instructions in only the most relevant place, and trust the reader to work it out from there.

Thoughts?